### PR TITLE
Update Amqp.ts

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -117,7 +117,7 @@ export default class Amqp extends Broker {
     this.callback = (await this.channel.assertQueue('', { exclusive: true })).queue;
     this.channel.consume(this.callback, (msg) => {
       if (msg) this._responses.emit(msg.properties.correlationId, decode(msg.content));
-    }, { noAck: true });
+    }, { noAck: true, durable: false });
 
     await this.channel.assertExchange(this.group, 'direct');
     return connection;

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -114,12 +114,12 @@ export default class Amqp extends Broker {
     this.channel = await connection.createChannel();
 
     // setup RPC callback queue
-    this.callback = (await this.channel.assertQueue('', { exclusive: true })).queue;
+    this.callback = (await this.channel.assertQueue('', { exclusive: true, durable: false })).queue;
     this.channel.consume(this.callback, (msg) => {
       if (msg) this._responses.emit(msg.properties.correlationId, decode(msg.content));
     }, { noAck: true, durable: false });
 
-    await this.channel.assertExchange(this.group, 'direct');
+    await this.channel.assertExchange(this.group, 'direct', { durable: false });
     return connection;
   }
 


### PR DESCRIPTION
fixes errors while connecting to amqp - `Error: Channel closed by server: 406 (PRECONDITION-FAILED) with message "PRECONDITION_FAILED - inequivalent arg 'durable' for exchange 'commands' in vhost '/'`